### PR TITLE
修复文本超出 拖拽框时 页面UI异常

### DIFF
--- a/src/views/posterEditor/main/widgets/textWidget.vue
+++ b/src/views/posterEditor/main/widgets/textWidget.vue
@@ -112,6 +112,7 @@ export default {
     margin: 10px;
     width: calc(100% - 20px);
     height: calc(100% - 20px);
+    overflow: hidden;
     white-space: wrap;
     word-break: break-all;
     &.editing {


### PR DESCRIPTION
修复文本超出 拖拽框时 页面UI异常
bugfix: #20:添加文字的时候遇到的bug  （ #20 opened on Jun 25, 2021 by wzqiang1332）